### PR TITLE
Add support for settings.ini file

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,11 +7,12 @@ from src.cli import (
     download_files,
     upload_files,
     spaces,
-    config,
 )
+from src.config import init
 
 
 if __name__ == "__main__":
+    init()
     fire.Fire(
         {
             "create": create_space,
@@ -21,6 +22,5 @@ if __name__ == "__main__":
             "download": download_files,
             "upload": upload_files,
             "spaces": spaces,
-            "config": config,
         }
     )

--- a/src/config.py
+++ b/src/config.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import configparser
 from dotenv import load_dotenv
 
 # https://stackoverflow.com/questions/41864951/pyinstaller-3-adding-datafiles-with-onefile/42145611#42145611
@@ -11,8 +12,37 @@ else:
 load_dotenv(dotenv_path=os.path.join(extDataDir, ".env"))
 
 
+def init():
+    file_path = os.path.join(os.getenv("HOME"), ".floatingfile", "settings.ini")
+    if not os.path.isfile(file_path):
+        config = configparser.ConfigParser()
+        config["profile"] = {"username": "Anonymous"}
+        config["download"] = {"dir": "Downloads", "group_by_space": "Yes"}
+        with open(file_path, "w") as f:
+            config.write(f)
+
+
 API_URL = os.getenv("API_URL")
 API_KEY = os.getenv("API_KEY")
+
+
+config = configparser.ConfigParser()
+
+
+def get_username():
+    config.read(os.path.join(os.getenv("HOME"), ".floatingfile", "settings.ini"))
+    return config["profile"]["username"]
+
+
+def get_download_path(code=None):
+    config.read(os.path.join(os.getenv("HOME"), ".floatingfile", "settings.ini"))
+
+    download_dir = config["download"]["dir"]
+    group_by_space = config["download"]["group_by_space"]
+
+    if group_by_space == "Yes":
+        return os.path.join(os.getenv("HOME"), download_dir, code)
+    return os.path.join(os.getenv("HOME"), download_dir)
 
 
 BASE_HEADERS = {"api-key": API_KEY}

--- a/src/models/Space.py
+++ b/src/models/Space.py
@@ -3,9 +3,8 @@ import os
 import json
 import mimetypes
 from ..errors import SpaceNotFoundError, MaxCapacityReached
-from ..config import API_URL, BASE_HEADERS
+from ..config import API_URL, BASE_HEADERS, get_username
 from ..utils import best_effort_file_type
-from ..services.username import get_username
 
 
 class Space:

--- a/src/services/username.py
+++ b/src/services/username.py
@@ -1,9 +1,0 @@
-from ..storage import Storage
-
-
-def get_username():
-    store = Storage("settings.pkl")
-    data = store.read()
-    if len(data) == 0:
-        return ""
-    return data["username"]


### PR DESCRIPTION
This PR adds support for a `settings.ini` file that is used to control the behaviour of floatingfile. The default `settings.ini` (found in `~/.floatingfile/settings.ini`) file looks like this:
```
[profile]
username = Anonymous

[download]
dir = Downloads
group_by_space = Yes
```

With the addition of these settings, the download method has been updated to use the default download directory specified by the settings file. If `group_by_spaces` is enabled (`Yes`), then downloads will create another directory using the space's code within the default download directory. For example, a file path might look like: `~/Downloads/ABC123/README.md`. 

As a dedicated settings file is now supported, the **configuration method (`floatingfile config`) has been removed** as any changes should now be done directly in the settings file. 